### PR TITLE
Namespace bug fix

### DIFF
--- a/ray_provider/hooks/ray.py
+++ b/ray_provider/hooks/ray.py
@@ -477,7 +477,7 @@ class RayHook(KubernetesHook):  # type: ignore
             kind = cluster_spec["kind"]
             plural = f"{kind.lower()}s" if kind == "RayCluster" else kind
             name = cluster_spec["metadata"]["name"]
-            namespace = self.get_namespace()
+            namespace = self.namespace
             api_version = cluster_spec["apiVersion"]
             group, version = api_version.split("/") if "/" in api_version else ("", api_version)
 
@@ -515,7 +515,7 @@ class RayHook(KubernetesHook):  # type: ignore
         kind = cluster_spec["kind"]
         plural = f"{kind.lower()}s" if kind == "RayCluster" else kind
         name = cluster_spec["metadata"]["name"]
-        namespace = self.get_namespace()
+        namespace = self.namespace
         api_version = cluster_spec["apiVersion"]
         group, version = api_version.split("/") if "/" in api_version else ("", api_version)
 


### PR DESCRIPTION
While setting up a Ray cluster on K8, we need to provide namespace option.

The expected behavior is to pick the namespace provided in the connection (using `self.get_namespace()`) or use `default`

The code though has a bug. If the namespace is not provided in the connection, it does not use the default.

This is because the variable created in the init method is not used in the setup_ray_cluster & delete_ray_cluster methods. Instead a direct call is made to `self.get_namespace()`

This PR fixes that bug