### PR TITLE
Attempt CI fix wrt broken coverage upload artifact

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,6 +66,7 @@ jobs:
         with:
           name: coverage-unit-test-${{ matrix.python-version }}-${{ matrix.airflow-version }}
           path: .coverage
+          include-hidden-files: true
 
   Run-Integration-Tests:
     needs: Authorize
@@ -139,6 +140,7 @@ jobs:
         with:
           name: coverage-integration-test-${{ matrix.python-version }}-${{ matrix.airflow-version }}
           path: .coverage
+          include-hidden-files: true
       - name: Delete GKE cluster
         if: always()
         run: |


### PR DESCRIPTION
Apparently the GitHub action https://github.com/actions/upload-artifact released a breaking change  https://github.com/actions/upload-artifact/issues/602 (not following semver guidelines) which is affecting our CodeCov job as it's no longer
able to download artifacts that were supposed to be uploaded from our tests in earlier jobs in the CI.

According to suggestion in https://github.com/actions/upload-artifact/pull/607/files, set include `include-hidden-files: true`, so that our workflow continues to work as it was before.