### PR TITLE
Release 0.2.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,15 @@
 CHANGELOG
 =========
 
+0.2.1 (2024-09-04)
+------------------
+
+**Bug fixes**
+Namespace variable initialized in init method is not used in setup_ray_cluster and delete_ray_cluster methods
+CI/CD pipeline broken due to sudden github action breaking change
+
+
+
 0.2.0 (2024-08-29)
 ------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,7 +9,7 @@
 project = "astro-provider-ray"
 copyright = "2024, Astronomer"
 author = "Astronomer"
-release = "0.2.0"
+release = "0.2.1"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/ray_provider/__init__.py
+++ b/ray_provider/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 
 from typing import Any
 


### PR DESCRIPTION
**Release-0.2.1**

**Bug fixes**
Namespace variable initialized in init method is not used in setup_ray_cluster and delete_ray_cluster methods
CI/CD pipeline broken due to sudden github action breaking change
