### PR TITLE
Bugfix: Better exception handling and cluster clean up

### DIFF
--- a/ray_provider/operators/ray.py
+++ b/ray_provider/operators/ray.py
@@ -175,6 +175,19 @@ class SubmitRayJob(BaseOperator):
         self.job_id = ""
         self.terminal_states = {JobStatus.SUCCEEDED, JobStatus.STOPPED, JobStatus.FAILED}
 
+        self.on_failure_callback = self._on_failure_callback
+        self.on_success_callback = self._on_success_callback
+
+    def _on_failure_callback(self, context: Context) -> None:
+        """Callback for task failure."""
+        self.log.info("Executing failure callback")
+        self._delete_cluster()
+
+    def _on_success_callback(self, context: Context) -> None:
+        """Callback for task success."""
+        self.log.info("Executing success callback")
+        self._delete_cluster()
+
     def on_kill(self) -> None:
         """
         Delete the Ray job if the task is killed.
@@ -288,6 +301,8 @@ class SubmitRayJob(BaseOperator):
                         job_id=self.job_id,
                         conn_id=self.conn_id,
                         xcom_dashboard_url=self.dashboard_url,
+                        ray_cluster_yaml=self.ray_cluster_yaml,
+                        gpu_device_plugin_yaml=self.gpu_device_plugin_yaml,
                         poll_interval=self.poll_interval,
                         fetch_logs=self.fetch_logs,
                     ),

--- a/ray_provider/operators/ray.py
+++ b/ray_provider/operators/ray.py
@@ -175,19 +175,6 @@ class SubmitRayJob(BaseOperator):
         self.job_id = ""
         self.terminal_states = {JobStatus.SUCCEEDED, JobStatus.STOPPED, JobStatus.FAILED}
 
-        self.on_failure_callback = self._on_failure_callback
-        self.on_success_callback = self._on_success_callback
-
-    def _on_failure_callback(self, context: Context) -> None:
-        """Callback for task failure."""
-        self.log.info("Executing failure callback")
-        self._delete_cluster()
-
-    def _on_success_callback(self, context: Context) -> None:
-        """Callback for task success."""
-        self.log.info("Executing success callback")
-        self._delete_cluster()
-
     def on_kill(self) -> None:
         """
         Delete the Ray job if the task is killed.
@@ -198,8 +185,7 @@ class SubmitRayJob(BaseOperator):
         if hasattr(self, "hook") and self.job_id:
             self.log.info(f"Deleting Ray job {self.job_id} due to task kill.")
             self.hook.delete_ray_job(self.dashboard_url, self.job_id)
-        if self.ray_cluster_yaml:
-            self._delete_cluster()
+        self._delete_cluster()
 
     @cached_property
     def hook(self) -> PodOperatorHookProtocol:
@@ -275,50 +261,55 @@ class SubmitRayJob(BaseOperator):
         :raises AirflowException: If the job fails, is cancelled, or reaches an unexpected state.
         """
 
-        self._setup_cluster(context=context)
+        try:
+            self._setup_cluster(context=context)
 
-        self.dashboard_url = self._get_dashboard_url(context)
+            self.dashboard_url = self._get_dashboard_url(context)
 
-        self.job_id = self.hook.submit_ray_job(
-            dashboard_url=self.dashboard_url,
-            entrypoint=self.entrypoint,
-            runtime_env=self.runtime_env,
-            entrypoint_num_cpus=self.num_cpus,
-            entrypoint_num_gpus=self.num_gpus,
-            entrypoint_memory=self.memory,
-            entrypoint_resources=self.ray_resources,
-        )
-        self.log.info(f"Ray job submitted with id: {self.job_id}")
+            self.job_id = self.hook.submit_ray_job(
+                dashboard_url=self.dashboard_url,
+                entrypoint=self.entrypoint,
+                runtime_env=self.runtime_env,
+                entrypoint_num_cpus=self.num_cpus,
+                entrypoint_num_gpus=self.num_gpus,
+                entrypoint_memory=self.memory,
+                entrypoint_resources=self.ray_resources,
+            )
+            self.log.info(f"Ray job submitted with id: {self.job_id}")
 
-        if self.wait_for_completion:
-            current_status = self.hook.get_ray_job_status(self.dashboard_url, self.job_id)
-            self.log.info(f"Current job status for {self.job_id} is: {current_status}")
+            if self.wait_for_completion:
+                current_status = self.hook.get_ray_job_status(self.dashboard_url, self.job_id)
+                self.log.info(f"Current job status for {self.job_id} is: {current_status}")
 
-            if current_status not in self.terminal_states:
-                self.log.info("Deferring the polling to RayJobTrigger...")
-                self.defer(
-                    trigger=RayJobTrigger(
-                        job_id=self.job_id,
-                        conn_id=self.conn_id,
-                        xcom_dashboard_url=self.dashboard_url,
-                        ray_cluster_yaml=self.ray_cluster_yaml,
-                        gpu_device_plugin_yaml=self.gpu_device_plugin_yaml,
-                        poll_interval=self.poll_interval,
-                        fetch_logs=self.fetch_logs,
-                    ),
-                    method_name="execute_complete",
-                    timeout=timedelta(seconds=self.job_timeout_seconds),
-                )
-            elif current_status == JobStatus.SUCCEEDED:
-                self.log.info("Job %s completed successfully", self.job_id)
-            elif current_status == JobStatus.FAILED:
-                raise AirflowException(f"Job failed:\n{self.job_id}")
-            elif current_status == JobStatus.STOPPED:
-                raise AirflowException(f"Job was cancelled:\n{self.job_id}")
-            else:
-                raise AirflowException(f"Encountered unexpected state `{current_status}` for job_id `{self.job_id}`")
-
-        return self.job_id
+                if current_status not in self.terminal_states:
+                    self.log.info("Deferring the polling to RayJobTrigger...")
+                    self.defer(
+                        trigger=RayJobTrigger(
+                            job_id=self.job_id,
+                            conn_id=self.conn_id,
+                            xcom_dashboard_url=self.dashboard_url,
+                            ray_cluster_yaml=self.ray_cluster_yaml,
+                            gpu_device_plugin_yaml=self.gpu_device_plugin_yaml,
+                            poll_interval=self.poll_interval,
+                            fetch_logs=self.fetch_logs,
+                        ),
+                        method_name="execute_complete",
+                        timeout=timedelta(seconds=self.job_timeout_seconds),
+                    )
+                elif current_status == JobStatus.SUCCEEDED:
+                    self.log.info("Job %s completed successfully", self.job_id)
+                elif current_status == JobStatus.FAILED:
+                    raise AirflowException(f"Job failed:\n{self.job_id}")
+                elif current_status == JobStatus.STOPPED:
+                    raise AirflowException(f"Job was cancelled:\n{self.job_id}")
+                else:
+                    raise AirflowException(
+                        f"Encountered unexpected state `{current_status}` for job_id `{self.job_id}`"
+                    )
+            return self.job_id
+        except Exception as e:
+            self._delete_cluster()
+            raise AirflowException(f"SubmitRayJob operator failed due to {e}. Cleaning up resources...")
 
     def execute_complete(self, context: Context, event: dict[str, Any]) -> None:
         """

--- a/ray_provider/triggers/ray.py
+++ b/ray_provider/triggers/ray.py
@@ -74,8 +74,12 @@ class RayJobTrigger(BaseTrigger):
 
     async def cleanup(self) -> None:
         """
-        Cleanup method to ensure resources are properly released.
-        This will be called when the trigger encounters an exception.
+        Cleanup method to ensure resources are properly deleted. This will be called when the trigger encounters an exception.
+
+        Example scenario: A job is submitted using the @ray.task decorator with a Ray specification. After the cluster is started
+        and the job is submitted, the trigger begins tracking its progress. However, if the job is stopped through the UI at this stage, the cluster
+        resources are not deleted.
+
         """
         try:
             if self.ray_cluster_yaml:

--- a/tests/triggers/test_ray_triggers.py
+++ b/tests/triggers/test_ray_triggers.py
@@ -14,6 +14,8 @@ class TestRayJobTrigger:
             job_id="test_job_id",
             conn_id="test_conn",
             xcom_dashboard_url="http://test-dashboard.com",
+            ray_cluster_yaml="test.yaml",
+            gpu_device_plugin_yaml="nvidia.yaml",
             poll_interval=1,
             fetch_logs=True,
         )
@@ -24,7 +26,14 @@ class TestRayJobTrigger:
     async def test_run_no_job_id(self, mock_hook, mock_is_terminal):
         mock_is_terminal.return_value = True
         mock_hook.get_ray_job_status.return_value = JobStatus.FAILED
-        trigger = RayJobTrigger(job_id="", poll_interval=1, conn_id="test", xcom_dashboard_url="test")
+        trigger = RayJobTrigger(
+            job_id="",
+            poll_interval=1,
+            conn_id="test",
+            xcom_dashboard_url="test",
+            ray_cluster_yaml="test.yaml",
+            gpu_device_plugin_yaml="nvidia.yaml",
+        )
         generator = trigger.run()
         event = await generator.asend(None)
         assert event == TriggerEvent(
@@ -37,7 +46,14 @@ class TestRayJobTrigger:
     async def test_run_job_succeeded(self, mock_hook, mock_is_terminal):
         mock_is_terminal.side_effect = [False, True]
         mock_hook.get_ray_job_status.return_value = JobStatus.SUCCEEDED
-        trigger = RayJobTrigger(job_id="test_job_id", poll_interval=1, conn_id="test", xcom_dashboard_url="test")
+        trigger = RayJobTrigger(
+            job_id="test_job_id",
+            poll_interval=1,
+            conn_id="test",
+            xcom_dashboard_url="test",
+            ray_cluster_yaml="test.yaml",
+            gpu_device_plugin_yaml="nvidia.yaml",
+        )
         generator = trigger.run()
         event = await generator.asend(None)
         assert event == TriggerEvent(
@@ -149,6 +165,8 @@ class TestRayJobTrigger:
                 "job_id": "test_job_id",
                 "conn_id": "test_conn",
                 "xcom_dashboard_url": "http://test-dashboard.com",
+                "ray_cluster_yaml": "test.yaml",
+                "gpu_device_plugin_yaml": "nvidia.yaml",
                 "fetch_logs": True,
                 "poll_interval": 1,
             },

--- a/tests/triggers/test_ray_triggers.py
+++ b/tests/triggers/test_ray_triggers.py
@@ -1,4 +1,5 @@
-from unittest.mock import patch
+import logging
+from unittest.mock import AsyncMock, call, patch
 
 import pytest
 from airflow.triggers.base import TriggerEvent
@@ -122,23 +123,6 @@ class TestRayJobTrigger:
         )
 
     @pytest.mark.asyncio
-    @patch("ray_provider.triggers.ray.RayJobTrigger._is_terminal_state")
-    @patch("ray_provider.triggers.ray.RayJobTrigger.hook")
-    async def test_run_with_exception(self, mock_hook, mock_is_terminal, trigger):
-        mock_is_terminal.side_effect = Exception("Test exception")
-
-        generator = trigger.run()
-        event = await generator.asend(None)
-
-        assert event == TriggerEvent(
-            {
-                "status": str(JobStatus.FAILED),
-                "message": "Test exception",
-                "job_id": "test_job_id",
-            }
-        )
-
-    @pytest.mark.asyncio
     @patch("ray_provider.triggers.ray.RayJobTrigger.hook")
     async def test_stream_logs(self, mock_hook, trigger):
         # Create a mock async iterator
@@ -184,3 +168,74 @@ class TestRayJobTrigger:
         assert not trigger._is_terminal_state()
         assert not trigger._is_terminal_state()
         assert trigger._is_terminal_state()
+
+    @pytest.mark.asyncio
+    @patch.object(RayJobTrigger, "hook")
+    @patch.object(logging.Logger, "info")
+    async def test_cleanup_with_cluster_yaml(self, mock_log_info, mock_hook, trigger):
+        await trigger.cleanup()
+
+        mock_log_info.assert_has_calls(
+            [
+                call("Attempting to delete Ray cluster using YAML: test.yaml"),
+                call("Ray cluster deletion process completed"),
+            ]
+        )
+        mock_hook.delete_ray_cluster.assert_called_once_with("test.yaml", "nvidia.yaml")
+
+    @pytest.mark.asyncio
+    @patch.object(logging.Logger, "info")
+    async def test_cleanup_without_cluster_yaml(self, mock_log_info):
+        trigger = RayJobTrigger(
+            job_id="test_job_id",
+            conn_id="test_conn",
+            xcom_dashboard_url="http://test-dashboard.com",
+            ray_cluster_yaml=None,
+            gpu_device_plugin_yaml="nvidia.yaml",
+            poll_interval=1,
+            fetch_logs=True,
+        )
+
+        await trigger.cleanup()
+
+        mock_log_info.assert_called_once_with("No Ray cluster YAML provided, skipping cluster deletion")
+
+    @pytest.mark.asyncio
+    @patch.object(RayJobTrigger, "hook")
+    @patch.object(logging.Logger, "error")
+    async def test_cleanup_with_exception(self, mock_log_error, mock_hook, trigger):
+        mock_hook.delete_ray_cluster.side_effect = Exception("Test exception")
+
+        await trigger.cleanup()
+
+        mock_log_error.assert_called_once_with("Unexpected error during cleanup: Test exception")
+
+    @pytest.mark.asyncio
+    @patch("asyncio.sleep", new_callable=AsyncMock)
+    @patch("ray_provider.triggers.ray.RayJobTrigger._is_terminal_state")
+    async def test_poll_status(self, mock_is_terminal, mock_sleep, trigger):
+        mock_is_terminal.side_effect = [False, False, True]
+
+        await trigger._poll_status()
+
+        assert mock_sleep.call_count == 2
+        mock_sleep.assert_called_with(1)
+
+    @pytest.mark.asyncio
+    @patch("ray_provider.triggers.ray.RayJobTrigger._is_terminal_state")
+    @patch("ray_provider.triggers.ray.RayJobTrigger.hook")
+    @patch("ray_provider.triggers.ray.RayJobTrigger.cleanup")
+    async def test_run_with_exception(self, mock_cleanup, mock_hook, mock_is_terminal, trigger):
+        mock_is_terminal.side_effect = Exception("Test exception")
+
+        generator = trigger.run()
+        event = await generator.asend(None)
+
+        assert event == TriggerEvent(
+            {
+                "status": str(JobStatus.FAILED),
+                "message": "Test exception",
+                "job_id": "test_job_id",
+            }
+        )
+        mock_cleanup.assert_called_once()


### PR DESCRIPTION
This PR fixes a bug for cleaning up cluster resources when they are no longer required.

We make 2 changes -- 

1. **SubmitRayJob** -- Add better exception handling to ensure cluster is deleted if there is an exception in the execute() method
2. **RayJobTrigger** -- Added cleanup methods to ensure that even if there is an exception when the trigger is running, the cluster clean up still happens. This was not the case earlier

Also added additional unit tests for both operator & trigger to ensure high code coverage.


