### PR TITLE
Bug fix: Allowing tests to run for PRs from forked repos

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,8 +2,8 @@ name: test
 on:
   push:
     branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
+  pull_request_target:
+    branches: ["main"]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches: [ "main" ]
   pull_request:
-      branches: [ "main" ]
+    branches: [ "main" ]
   pull_request_target:
     branches: ["main"]
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,8 @@ name: test
 on:
   push:
     branches: [ "main" ]
+  pull_request:
+      branches: [ "main" ]
   pull_request_target:
     branches: ["main"]
 


### PR DESCRIPTION
The test workflow runs integration tests using an external GKE cluster and therefore requires some credentials.

The integration test currently fails when it is run on PRs from forked repos.

This PR fixes this issue using `pull_request_target`. 

See here for more information:
https://github.com/astronomer/astronomer-cosmos/blob/main/.github/workflows/test.yml
https://datachain.ai/blog/testing-external-contributions-using-github-actions-secrets
