### PR TITLE
Fix integration test and bug in load balancer wait logic

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,11 @@ test-cov = 'sh scripts/test/unit_cov.sh'
 test-integration = 'sh scripts/test/integration_test.sh'
 static-check = "pre-commit run --all-files"
 
+[tool.pytest.ini_options]
+filterwarnings = ["ignore::DeprecationWarning"]
+minversion = "6.0"
+markers = ["integration"]
+
 ######################################
 # DOCS
 ######################################

--- a/ray_provider/hooks/ray.py
+++ b/ray_provider/hooks/ray.py
@@ -339,6 +339,7 @@ class RayHook(KubernetesHook):  # type: ignore
 
                 if not lb_details:
                     self.log.info("LoadBalancer details not available yet.")
+                    time.sleep(retry_interval)
                     continue
 
                 working_address = self._check_load_balancer_readiness(lb_details)

--- a/tests/test_dag_example.py
+++ b/tests/test_dag_example.py
@@ -63,7 +63,7 @@ def test_dag_runs(setup_airflow_db, dag_id, dag, fileloc):
     if dag_id != "Ray_Taskflow_Example":
         return
 
-    try:
-        dag.test()
-    except Exception as e:
-        pytest.fail(f"Error running DAG {dag_id}: {e}")
+    #try:
+    dag.test()
+    # except Exception as e:
+    #     pytest.fail(f"Error running DAG {dag_id}: {e}")

--- a/tests/test_dag_example.py
+++ b/tests/test_dag_example.py
@@ -63,7 +63,8 @@ def test_dag_runs(setup_airflow_db, dag_id, dag, fileloc):
     if dag_id != "Ray_Taskflow_Example":
         return
 
-    #try:
-    dag.test()
-    # except Exception as e:
-    #     pytest.fail(f"Error running DAG {dag_id}: {e}")
+    try:
+        dr = dag.test()
+        assert dr.state == "success"
+    except Exception as e:
+        pytest.fail(f"Error running DAG {dag_id}: {e}")


### PR DESCRIPTION
I noticed that sometimes dag.test() does not raise an exception even when an Airflow task fails, leading to silent failures in CI jobs without any notification. To address this, I’ve added an explicit assertion to check that the DAG run state is "success" when dag.test() does not raise an exception.

Added the tool.pytest.ini_options section in pyproject.toml, including the minversion option and custom markers.

Fixed bug in the sleep logic while waiting for the load balancer to become ready

Failed detected CI: https://github.com/astronomer/astro-provider-ray/actions/runs/11560564529/job/32177695161?pr=85

closes: https://github.com/astronomer/oss-integrations-private/issues/22