### PR TITLE
[Docs] Fix dead reference in docs index page

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,7 +28,7 @@ Table of Contents
 -----------------
 
 - `Quickstart`_
-- `What is the Ray provider?`_
+- `Why use Airflow with Ray?`_
 - `Components`_
 - `Getting Involved`_
 - `Changelog`_


### PR DESCRIPTION
This PR fixes the broken reference in the docs home page table content https://astronomer.github.io/astro-provider-ray/

Before this PR:
---------------

<img width="330" alt="Screenshot 2024-10-29 at 5 16 12 PM" src="https://github.com/user-attachments/assets/78b7b5f4-1cb9-4262-b03b-128392634784">


After this PR:
-------------

<img width="330" alt="Screenshot 2024-10-29 at 5 16 53 PM" src="https://github.com/user-attachments/assets/7a0837aa-8677-4aea-b557-a170a05fe95d">
