### PR TITLE
Add Airflow 2.10 (released in August 2024) to tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,7 @@
 name: test
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main" , "test-airflow-2.10" ]
   pull_request_target:
     branches: ["main"]
 
@@ -34,7 +34,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-        airflow-version: ["2.7", "2.8", "2.9"]
+        airflow-version: ["2.7", "2.8", "2.9", "2.10"]
         exclude:
           - python-version: "3.12"
             airflow-version: "2.7"
@@ -74,7 +74,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.11"]
-        airflow-version: ["2.9"]
+        airflow-version: ["2.10"]
     permissions:
       contents: 'read'
       id-token: 'write'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,7 @@
 name: test
 on:
   push:
-    branches: [ "main" , "test-airflow-2.10" ]
+    branches: [ "main" ]
   pull_request_target:
     branches: ["main"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ pre-install-commands = ["sh scripts/test/pre-install-airflow.sh {matrix:airflow}
 
 [[tool.hatch.envs.tests.matrix]]
 python = ["3.8", "3.9", "3.10", "3.11", "3.12"]
-airflow = ["2.7", "2.8", "2.9"]
+airflow = ["2.7", "2.8", "2.9", "2.10"]
 
 [tool.hatch.envs.tests.scripts]
 freeze = "pip freeze"


### PR DESCRIPTION
Previously, the test matrix did not include Airflow 2.10, released in August 2024.

This PR changes this, ensuring we run our integration tests against the latest stable version of Airflow.

Example of successful run: https://github.com/astronomer/astro-provider-ray/actions/runs/12053126781