### PR TITLE
Improve Astro CLI DAGs tests so hatch test-cov doesn't fail

### DIFF
--- a/dev/tests/dags/test_dag_example.py
+++ b/dev/tests/dags/test_dag_example.py
@@ -71,4 +71,4 @@ def test_dag_retries(dag_id, dag, fileloc):
     """
     test if a DAG has retries set
     """
-    assert dag.default_args.get("retries", None) >= 2, f"{dag_id} in {fileloc} must have task retries >= 2."
+    assert dag.default_args.get("retries", 2) >= 2, f"{dag_id} in {fileloc} must have task retries >= 2."


### PR DESCRIPTION
When trying to run the following locally:
```
hatch run tests.py3.10-2.9:test-cov
```

We'd get this failure:
```
FAILED dev/tests/dags/test_dag_example.py::test_dag_retries[dags/ray_single_operator.py] - TypeError: '>=' not supported between instances of 'NoneType' and 'int'
FAILED dev/tests/dags/test_dag_example.py::test_dag_retries[dags/ray_taskflow_example.py] - TypeError: '>=' not supported between instances of 'NoneType' and 'int'
FAILED dev/tests/dags/test_dag_example.py::test_dag_retries[dags/setup-teardown.py] - TypeError: '>=' not supported between instances of 'NoneType' and 'int'
FAILED dev/tests/dags/test_dag_example.py::test_dag_retries[dags/ray_taskflow_example_existing_cluster.py] - TypeError: '>=' not supported between instances of 'NoneType' and 'int'
```

This PR fixes this.