### PR TITLE
Stop catching generic `Exception` in triggerer 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,9 @@ build-whl: setup-dev ## Build installable whl file
 	# Delete any previous wheels, so different versions don't conflict
 	rm dev/include/*
 	cd dev
+        # delete potential previous versions, otherwise there will be a conflict
+        # during installation
+        rm include/*
 	python3 -m build --outdir dev/include/
 
 .PHONY: docker-run

--- a/ray_provider/constants.py
+++ b/ray_provider/constants.py
@@ -1,0 +1,3 @@
+from ray.job_submission import JobStatus
+
+TERMINAL_JOB_STATUSES = {JobStatus.SUCCEEDED, JobStatus.STOPPED, JobStatus.FAILED}

--- a/ray_provider/constants.py
+++ b/ray_provider/constants.py
@@ -1,3 +1,4 @@
 from ray.job_submission import JobStatus
 
 TERMINAL_JOB_STATUSES = {JobStatus.SUCCEEDED, JobStatus.STOPPED, JobStatus.FAILED}
+

--- a/ray_provider/constants.py
+++ b/ray_provider/constants.py
@@ -1,4 +1,3 @@
 from ray.job_submission import JobStatus
 
 TERMINAL_JOB_STATUSES = {JobStatus.SUCCEEDED, JobStatus.STOPPED, JobStatus.FAILED}
-

--- a/ray_provider/triggers.py
+++ b/ray_provider/triggers.py
@@ -5,8 +5,10 @@ from functools import cached_property
 from typing import Any, AsyncIterator
 
 from airflow.triggers.base import BaseTrigger, TriggerEvent
+from kubernetes.client.exceptions import ApiException
 from ray.job_submission import JobStatus
 
+from ray_provider.constants import TERMINAL_JOB_STATUSES
 from ray_provider.hooks import RayHook
 
 
@@ -43,6 +45,7 @@ class RayJobTrigger(BaseTrigger):
         self.gpu_device_plugin_yaml = gpu_device_plugin_yaml
         self.fetch_logs = fetch_logs
         self.poll_interval = poll_interval
+        self._job_status = None | JobStatus
 
     def serialize(self) -> tuple[str, dict[str, Any]]:
         """
@@ -81,22 +84,22 @@ class RayJobTrigger(BaseTrigger):
         resources are not deleted.
 
         """
-        try:
-            if self.ray_cluster_yaml:
-                self.log.info(f"Attempting to delete Ray cluster using YAML: {self.ray_cluster_yaml}")
-                loop = asyncio.get_running_loop()
-                await loop.run_in_executor(
-                    None, self.hook.delete_ray_cluster, self.ray_cluster_yaml, self.gpu_device_plugin_yaml
-                )
-                self.log.info("Ray cluster deletion process completed")
-            else:
-                self.log.info("No Ray cluster YAML provided, skipping cluster deletion")
-        except Exception as e:
-            self.log.error(f"Unexpected error during cleanup: {str(e)}")
+        if self.ray_cluster_yaml:
+            self.log.info(f"Attempting to delete Ray cluster using YAML: {self.ray_cluster_yaml}")
+            loop = asyncio.get_running_loop()
+            await loop.run_in_executor(
+                None, self.hook.delete_ray_cluster, self.ray_cluster_yaml, self.gpu_device_plugin_yaml
+            )
+            self.log.info("Ray cluster deletion process completed")
+        else:
+            self.log.info("No Ray cluster YAML provided, skipping cluster deletion")
 
     async def _poll_status(self) -> None:
-        while not self._is_terminal_state():
+        self._job_status = self.hook.get_ray_job_status(self.dashboard_url, self.job_id)
+        while self._job_status not in TERMINAL_JOB_STATUSES:
+            self.log.info(f"Status of job {self.job_id} is: {self._job_status}")
             await asyncio.sleep(self.poll_interval)
+            self._job_status = self.hook.get_ray_job_status(self.dashboard_url, self.job_id)
 
     async def _stream_logs(self) -> None:
         """
@@ -111,46 +114,42 @@ class RayJobTrigger(BaseTrigger):
 
     async def run(self) -> AsyncIterator[TriggerEvent]:
         """
-        Asynchronously polls the job status and yields events based on the job's state.
+        Asynchronously polls the Ray job status and yields events based on the job's state.
 
         This method gets job status at each poll interval and streams logs if available.
         It yields a TriggerEvent upon job completion, cancellation, or failure.
 
         :yield: TriggerEvent containing the status, message, and job ID related to the job.
         """
-        try:
-            self.log.info(f"Polling for job {self.job_id} every {self.poll_interval} seconds...")
+        self.log.info(f"::group:: Trigger 1/2: Checking the job status")
+        self.log.info(f"Polling for job {self.job_id} every {self.poll_interval} seconds...")
 
+        try:
             tasks = [self._poll_status()]
             if self.fetch_logs:
                 tasks.append(self._stream_logs())
-
             await asyncio.gather(*tasks)
+        except ApiException as e:
+            error_msg = str(e)
+            self.log.info(f"::endgroup::")
+            self.log.error("::group:: Trigger unable to poll job status")
+            self.log.error("Exception details:", exc_info=True)
+            self.log.info("Attempting to clean up...")
+            await self.cleanup()
+            self.log.info("Cleanup completed!")
+            self.log.info(f"::endgroup::")
 
-            completed_status = self.hook.get_ray_job_status(self.dashboard_url, self.job_id)
-            self.log.info(f"Status of completed job {self.job_id} is: {completed_status}")
+            yield TriggerEvent({"status": "EXCEPTION", "message": error_msg, "job_id": self.job_id})
+        else:
+            self.log.info(f"::endgroup::")
+            self.log.info(f"::group:: Trigger 2/2: Job reached a terminal state")
+            self.log.info(f"Status of completed job {self.job_id} is: {self._job_status}")
+            self.log.info(f"::endgroup::")
+
             yield TriggerEvent(
                 {
-                    "status": completed_status,
-                    "message": f"Job {self.job_id} completed with status {completed_status}",
+                    "status": self._job_status,
+                    "message": f"Job {self.job_id} completed with status {self._job_status}",
                     "job_id": self.job_id,
                 }
             )
-        except Exception as e:
-            self.log.error(f"Error occurred: {str(e)}")
-            await self.cleanup()
-            yield TriggerEvent({"status": str(JobStatus.FAILED), "message": str(e), "job_id": self.job_id})
-
-    def _is_terminal_state(self) -> bool:
-        """
-        Checks if the Ray job is in a terminal state.
-
-        A terminal state is one of the following: SUCCEEDED, STOPPED, or FAILED.
-
-        :return: True if the job is in a terminal state, False otherwise.
-        """
-        return self.hook.get_ray_job_status(self.dashboard_url, self.job_id) in (
-            JobStatus.SUCCEEDED,
-            JobStatus.STOPPED,
-            JobStatus.FAILED,
-        )

--- a/ray_provider/triggers.py
+++ b/ray_provider/triggers.py
@@ -45,7 +45,7 @@ class RayJobTrigger(BaseTrigger):
         self.gpu_device_plugin_yaml = gpu_device_plugin_yaml
         self.fetch_logs = fetch_logs
         self.poll_interval = poll_interval
-        self._job_status = None | JobStatus
+        self._job_status: None | JobStatus = None
 
     def serialize(self) -> tuple[str, dict[str, Any]]:
         """

--- a/tests/test_triggers.py
+++ b/tests/test_triggers.py
@@ -64,7 +64,7 @@ class TestRayJobTrigger:
         )
 
     @pytest.mark.asyncio
-    @patch("ray_provider.triggers.RayJobTrigger.hook.get_ray_job_status", side_effect=[None, JobStatus.STOPPED])
+    @patch("ray_provider.triggers.RayJobTrigger.hook.get_ray_job_status", side_effect=[JobStatus.RUNNING, JobStatus.STOPPED])
     @patch("ray_provider.triggers.RayJobTrigger.hook")
     async def test_run_job_stopped(self, mock_hook, mock_job_status, trigger):
         generator = trigger.run()
@@ -79,7 +79,7 @@ class TestRayJobTrigger:
         )
 
     @pytest.mark.asyncio
-    @patch("ray_provider.triggers.RayJobTrigger.hook.get_ray_job_status", side_effect=[None, JobStatus.FAILED])
+    @patch("ray_provider.triggers.RayJobTrigger.hook.get_ray_job_status", side_effect=[JobStatus.RUNNING, JobStatus.FAILED])
     @patch("ray_provider.triggers.RayJobTrigger.hook")
     async def test_run_job_failed(self, mock_hook, mock_job_status, trigger):
         generator = trigger.run()
@@ -94,7 +94,7 @@ class TestRayJobTrigger:
         )
 
     @pytest.mark.asyncio
-    @patch("ray_provider.triggers.RayJobTrigger.hook.get_ray_job_status", side_effect=[None, JobStatus.SUCCEEDED])
+    @patch("ray_provider.triggers.RayJobTrigger.hook.get_ray_job_status", side_effect=[JobStatus.RUNNING, JobStatus.SUCCEEDED])
     @patch("ray_provider.triggers.RayJobTrigger.hook")
     @patch("ray_provider.triggers.RayJobTrigger._stream_logs")
     async def test_run_with_log_streaming(self, mock_stream_logs, mock_hook, mock_job_status, trigger):
@@ -179,7 +179,7 @@ class TestRayJobTrigger:
 
     @pytest.mark.asyncio
     @patch("asyncio.sleep", new_callable=AsyncMock)
-    @patch("ray_provider.triggers.RayJobTrigger.hook.get_ray_job_status", side_effect=[None, None, JobStatus.SUCCEEDED])
+    @patch("ray_provider.triggers.RayJobTrigger.hook.get_ray_job_status", side_effect=[JobStatus.RUNNING, JobStatus.RUNNING, JobStatus.SUCCEEDED])
     @patch("ray_provider.triggers.RayJobTrigger.hook")
     async def test_poll_status(self, mock_hook, mock_job_status, mock_sleep, trigger):
         await trigger._poll_status()

--- a/tests/test_triggers.py
+++ b/tests/test_triggers.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import logging
 from unittest.mock import AsyncMock, call, patch
 

--- a/tests/test_triggers.py
+++ b/tests/test_triggers.py
@@ -1,9 +1,9 @@
+from __future__ import annotations
 import logging
 from unittest.mock import AsyncMock, call, patch
 
 import pytest
 from airflow.triggers.base import TriggerEvent
-from __future__ import annotations
 from kubernetes.client.exceptions import ApiException
 from ray.job_submission import JobStatus
 

--- a/tests/test_triggers.py
+++ b/tests/test_triggers.py
@@ -43,7 +43,10 @@ class TestRayJobTrigger:
         )
 
     @pytest.mark.asyncio
-    @patch("ray_provider.triggers.RayJobTrigger.hook.get_ray_job_status", side_effect=[JobStatus.RUNNING, JobStatus.SUCCEEDED])
+    @patch(
+        "ray_provider.triggers.RayJobTrigger.hook.get_ray_job_status",
+        side_effect=[JobStatus.RUNNING, JobStatus.SUCCEEDED],
+    )
     @patch("ray_provider.triggers.RayJobTrigger.hook")
     async def test_run_job_succeeded(self, mock_hook, mock_job_status):
         trigger = RayJobTrigger(
@@ -65,7 +68,10 @@ class TestRayJobTrigger:
         )
 
     @pytest.mark.asyncio
-    @patch("ray_provider.triggers.RayJobTrigger.hook.get_ray_job_status", side_effect=[JobStatus.RUNNING, JobStatus.STOPPED])
+    @patch(
+        "ray_provider.triggers.RayJobTrigger.hook.get_ray_job_status",
+        side_effect=[JobStatus.RUNNING, JobStatus.STOPPED],
+    )
     @patch("ray_provider.triggers.RayJobTrigger.hook")
     async def test_run_job_stopped(self, mock_hook, mock_job_status, trigger):
         generator = trigger.run()
@@ -80,7 +86,9 @@ class TestRayJobTrigger:
         )
 
     @pytest.mark.asyncio
-    @patch("ray_provider.triggers.RayJobTrigger.hook.get_ray_job_status", side_effect=[JobStatus.RUNNING, JobStatus.FAILED])
+    @patch(
+        "ray_provider.triggers.RayJobTrigger.hook.get_ray_job_status", side_effect=[JobStatus.RUNNING, JobStatus.FAILED]
+    )
     @patch("ray_provider.triggers.RayJobTrigger.hook")
     async def test_run_job_failed(self, mock_hook, mock_job_status, trigger):
         generator = trigger.run()
@@ -95,7 +103,10 @@ class TestRayJobTrigger:
         )
 
     @pytest.mark.asyncio
-    @patch("ray_provider.triggers.RayJobTrigger.hook.get_ray_job_status", side_effect=[JobStatus.RUNNING, JobStatus.SUCCEEDED])
+    @patch(
+        "ray_provider.triggers.RayJobTrigger.hook.get_ray_job_status",
+        side_effect=[JobStatus.RUNNING, JobStatus.SUCCEEDED],
+    )
     @patch("ray_provider.triggers.RayJobTrigger.hook")
     @patch("ray_provider.triggers.RayJobTrigger._stream_logs")
     async def test_run_with_log_streaming(self, mock_stream_logs, mock_hook, mock_job_status, trigger):
@@ -180,7 +191,10 @@ class TestRayJobTrigger:
 
     @pytest.mark.asyncio
     @patch("asyncio.sleep", new_callable=AsyncMock)
-    @patch("ray_provider.triggers.RayJobTrigger.hook.get_ray_job_status", side_effect=[JobStatus.RUNNING, JobStatus.RUNNING, JobStatus.SUCCEEDED])
+    @patch(
+        "ray_provider.triggers.RayJobTrigger.hook.get_ray_job_status",
+        side_effect=[JobStatus.RUNNING, JobStatus.RUNNING, JobStatus.SUCCEEDED],
+    )
     @patch("ray_provider.triggers.RayJobTrigger.hook")
     async def test_poll_status(self, mock_hook, mock_job_status, mock_sleep, trigger):
         await trigger._poll_status()

--- a/tests/test_triggers.py
+++ b/tests/test_triggers.py
@@ -42,7 +42,7 @@ class TestRayJobTrigger:
         )
 
     @pytest.mark.asyncio
-    @patch("ray_provider.triggers.RayJobTrigger.hook.get_ray_job_status", side_effect=[None, JobStatus.SUCCEEDED])
+    @patch("ray_provider.triggers.RayJobTrigger.hook.get_ray_job_status", side_effect=[JobStatus.RUNNING, JobStatus.SUCCEEDED])
     @patch("ray_provider.triggers.RayJobTrigger.hook")
     async def test_run_job_succeeded(self, mock_hook, mock_job_status):
         trigger = RayJobTrigger(

--- a/tests/test_triggers.py
+++ b/tests/test_triggers.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock, call, patch
 
 import pytest
 from airflow.triggers.base import TriggerEvent
+from __future__ import annotations
 from kubernetes.client.exceptions import ApiException
 from ray.job_submission import JobStatus
 


### PR DESCRIPTION
By catching `Exception`, we risk hitting an unexpected exception that the program can't recover from, or worse, swallowing an important exception without properly logging it - a massive headache when trying to debug programs that are failing in weird ways.

If this change leads to any exceptions that should be caught being raised, we'll have the opportunity to understand which are those exceptions and capture them, handling them in a graceful way.

This was identified during https://github.com/astronomer/astro-provider-ray/issues/81 development.