### PR TITLE
Fix running `make docker-run` when there is a new version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,8 @@ setup-dev: ## Setup development environment
 
 .PHONY: build-whl
 build-whl: setup-dev ## Build installable whl file
+	# Delete any previous wheels, so different versions don't conflict
+	rm dev/include/*
 	cd dev
 	python3 -m build --outdir dev/include/
 


### PR DESCRIPTION
Previoulsy, we never deleted wheels. The consequence is that the include directory would contain multiple versions of the Ray provider package, which would raise an exception when trying to run `make docker-run`.

Example of error:
````

0.608 The conflict is caused by:
0.608     The user requested astro-provider-ray 0.2.1 (from /usr/local/airflow/include/astro_provider_ray-0.2.1-py3-none-any.whl)
0.608     The user requested astro-provider-ray 0.3.0a7 (from /usr/local/airflow/include/astro_provider_ray-0.3.0a7-py3-none-any.whl)
0.608
0.608 To fix this you could try to:
0.608 1. loosen the range of package versions you've specified
0.608 2. remove package versions to allow pip to attempt to solve the dependency conflict
0.608
0.825
0.825 [notice] A new release of pip is available: 24.2 -> 24.3.1
0.825 [notice] To update, run: pip install --upgrade pip
0.826 ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/topics/dependency-resolution/#dealing-with-dependency-conflicts
------
Dockerfile:25
--------------------
  23 |     USER astro
  24 |
  25 | >>> RUN pip install /usr/local/airflow/include/*.whl
  26 |
--------------------
ERROR: failed to solve: process "/bin/bash -o pipefail -e -u -x -c pip install /usr/local/airflow/include/*.whl" did not complete successfully: exit code: 1

View build details: docker-desktop://dashboard/build/desktop-linux/desktop-linux/17i8mx9qdqmd7fb72fe3uxjxc
Error: command 'docker build -t dev_c226a1/airflow:latest failed: failed to execute cmd: exit status 1
make: *** [docker-run] Error 1
```