### PR TITLE
Fix `RayHook` `conn_name_attr`

### DIFF
--- a/ray_provider/hooks.py
+++ b/ray_provider/hooks.py
@@ -26,7 +26,7 @@ class RayHook(KubernetesHook):  # type: ignore
     :param conn_id: The connection ID to use when fetching connection info.
     """
 
-    conn_name_attr = "ray_conn_id"
+    conn_name_attr = "conn_id"
     default_conn_name = "ray_default"
     conn_type = "ray"
     hook_name = "Ray"


### PR DESCRIPTION
Historically, someone assigned the incorrect value to this property.

It overrides the KubernetesHook and all the examples and tests (including `test_dag_example.py` actually use `conn_id`, as opposed to `ray_conn_id`.
