### PR TITLE
[DOCS] Add privacy policy and tracking pixel to docs for website analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,6 @@ A detailed overview on how to contribute can be found in the [Contributing Guide
 
 ## License
 [Apache 2.0 License](https://github.com/astronomer/astro-provider-ray/blob/main/LICENSE)
+
+## Privacy Notice
+This project follows `Astronomer's Privacy Policy <https://www.astronomer.io/privacy/>`_

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -151,4 +151,4 @@ This project follows `Astronomer's Privacy Policy <https://www.astronomer.io/pri
 .. Tracking pixel for Scarf
 .. raw:: html
 
-    <img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=56e87110-3304-40f8-b507-152628d91ec0" /> 
+    <img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=56e87110-3304-40f8-b507-152628d91ec0" />

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -142,3 +142,13 @@ All contributions, bug reports, bug fixes, documentation improvements, enhanceme
 A detailed overview an how to contribute can be found in the `Contributing Guide`_
 
 .. _Contributing Guide: https://github.com/astronomer/astro-provider-ray/blob/main/docs/CONTRIBUTING.rst
+
+Privacy Notice
+______________
+
+This project follows `Astronomer's Privacy Policy <https://www.astronomer.io/privacy/>`_
+
+.. Tracking pixel for Scarf
+.. raw:: html
+
+    <img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=56e87110-3304-40f8-b507-152628d91ec0" /> 


### PR DESCRIPTION
This adds a privacy notice and a tracking pixel to our auto-generated docs.

Note that while you cannot explicitly opt out of website analytics for the publicly hosted readme (and docs), Scarf respects browser DND. If that is set via the browser, telemetry for that user will not be sent to Scarf.

Scarf privacy policy: https://about.scarf.sh/privacy-policy
Astronomer privacy policy: https://www.astronomer.io/privacy/