### PR TITLE
Fix: convert headers from connection from string to dictionary

### DIFF
--- a/ray_provider/hooks.py
+++ b/ray_provider/hooks.py
@@ -89,7 +89,7 @@ class RayHook(KubernetesHook):  # type: ignore
         self.create_cluster_if_needed = False
         self.cookies = self._get_field("cookies")
         self.metadata = self._get_field("metadata")
-        self.headers = json.load(self._get_field("headers"))
+        self.headers = json.loads(self._get_field("headers"))
         self.verify = self._get_field("verify") or False
         self.ray_client_instance = None
 

--- a/ray_provider/hooks.py
+++ b/ray_provider/hooks.py
@@ -89,7 +89,7 @@ class RayHook(KubernetesHook):  # type: ignore
         self.create_cluster_if_needed = False
         self.cookies = self._get_field("cookies")
         self.metadata = self._get_field("metadata")
-        self.headers = json.loads(self._get_field("headers"))
+        self.headers = json.loads(self._get_field("headers") or "{}")
         self.verify = self._get_field("verify") or False
         self.ray_client_instance = None
 

--- a/ray_provider/hooks.py
+++ b/ray_provider/hooks.py
@@ -5,6 +5,7 @@ import socket
 import subprocess
 import tempfile
 import time
+import json
 from typing import Any, AsyncIterator
 
 import requests
@@ -88,7 +89,7 @@ class RayHook(KubernetesHook):  # type: ignore
         self.create_cluster_if_needed = False
         self.cookies = self._get_field("cookies")
         self.metadata = self._get_field("metadata")
-        self.headers = self._get_field("headers")
+        self.headers = json.load(self._get_field("headers"))
         self.verify = self._get_field("verify") or False
         self.ray_client_instance = None
 

--- a/ray_provider/hooks.py
+++ b/ray_provider/hooks.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
+import json
 import os
 import socket
 import subprocess
 import tempfile
 import time
-import json
 from typing import Any, AsyncIterator
 
 import requests

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -149,7 +149,7 @@ class TestRayHook:
             create_cluster_if_needed=False,
             cookies=None,
             metadata=None,
-            headers=None,
+            headers={},
             verify=False,
         )
         mock_client_instance.get_job_logs.assert_called_once_with(job_id=job_id)


### PR DESCRIPTION
The headers are retrieved from the connection as a string. But they are expected to be a dictionary. Getting the error:

```
ERROR - Failed during execution with error: Failed to create Ray JobSubmissionClient: headers must be a dict, got <class 'str'>
```

The fix is to use json.loads to convert the header to dict before assigning them to the headers attribute.

Fixes: #119

