### PR TITLE
Fix Static-Check + cncf-kubernetes compat (mypy, PodOperatorHookProtocol, dead link)

### DIFF
--- a/mlc-config.json
+++ b/mlc-config.json
@@ -7,6 +7,9 @@
   "ignorePatterns": [
     {
       "pattern": "^http://localhost:"
+    },
+    {
+      "pattern": "^https://join\\.slack\\.com/"
     }
   ],
   "retryCount": 5,

--- a/ray_provider/decorators.py
+++ b/ray_provider/decorators.py
@@ -10,13 +10,13 @@ from pathlib import Path
 from typing import Any, Callable
 
 from airflow.decorators.base import DecoratedOperator, TaskDecorator, task_decorator_factory
-from airflow.utils.context import Context
+from airflow.utils.context import Context  # type: ignore[attr-defined]
 
 from ray_provider.exceptions import RayAirflowException
 from ray_provider.operators import SubmitRayJob
 
 
-class _RayDecoratedOperator(DecoratedOperator, SubmitRayJob):
+class _RayDecoratedOperator(DecoratedOperator, SubmitRayJob):  # type: ignore[misc]
     """
     A custom Airflow operator for Ray tasks.
 

--- a/ray_provider/hooks.py
+++ b/ray_provider/hooks.py
@@ -10,9 +10,9 @@ from typing import Any, AsyncIterator
 
 import requests
 import yaml
-from airflow.exceptions import AirflowException
+from airflow.exceptions import AirflowException  # type: ignore[attr-defined]
 from airflow.providers.cncf.kubernetes.hooks.kubernetes import KubernetesHook
-from airflow.utils.context import Context
+from airflow.utils.context import Context  # type: ignore[attr-defined]
 from kubernetes import client, config
 from ray.job_submission import JobStatus, JobSubmissionClient
 

--- a/ray_provider/operators.py
+++ b/ray_provider/operators.py
@@ -5,7 +5,6 @@ from functools import cached_property
 from typing import Any
 
 from airflow.models import BaseOperator
-from airflow.providers.cncf.kubernetes.utils.pod_manager import PodOperatorHookProtocol
 from airflow.utils.context import Context  # type: ignore[attr-defined]
 from kubernetes.client.exceptions import ApiException
 from ray.job_submission import JobStatus
@@ -87,7 +86,7 @@ class DeleteRayCluster(BaseOperator):
         self.gpu_device_plugin_yaml = gpu_device_plugin_yaml
 
     @property
-    def hook(self) -> PodOperatorHookProtocol:
+    def hook(self) -> RayHook:
         """Lazily initialize and return the RayHook."""
         return RayHook(conn_id=self.conn_id)
 
@@ -193,7 +192,7 @@ class SubmitRayJob(BaseOperator):
         self._delete_cluster()
 
     @cached_property
-    def hook(self) -> PodOperatorHookProtocol:
+    def hook(self) -> RayHook:
         """Lazily initialize and return the RayHook."""
         return RayHook(conn_id=self.conn_id)
 

--- a/ray_provider/operators.py
+++ b/ray_provider/operators.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from airflow.models import BaseOperator
 from airflow.providers.cncf.kubernetes.utils.pod_manager import PodOperatorHookProtocol
-from airflow.utils.context import Context
+from airflow.utils.context import Context  # type: ignore[attr-defined]
 from kubernetes.client.exceptions import ApiException
 from ray.job_submission import JobStatus
 

--- a/ray_provider/triggers.py
+++ b/ray_provider/triggers.py
@@ -139,14 +139,14 @@ class RayJobTrigger(BaseTrigger):
             self.log.info("Cleanup completed!")
             self.log.info(f"::endgroup::")
 
-            yield TriggerEvent({"status": "EXCEPTION", "message": error_msg, "job_id": self.job_id})
+            yield TriggerEvent({"status": "EXCEPTION", "message": error_msg, "job_id": self.job_id})  # type: ignore[no-untyped-call]
         else:
             self.log.info(f"::endgroup::")
             self.log.info(f"::group:: Trigger 2/2: Job reached a terminal state")
             self.log.info(f"Status of completed job {self.job_id} is: {self._job_status}")
             self.log.info(f"::endgroup::")
 
-            yield TriggerEvent(
+            yield TriggerEvent(  # type: ignore[no-untyped-call]
                 {
                     "status": self._job_status,
                     "message": f"Job {self.job_id} completed with status {self._job_status}",


### PR DESCRIPTION
## Summary

`Static-Check` has been red on `main` (since the gate was added), and a recent `apache-airflow-providers-cncf-kubernetes` release additionally broke test collection. This fixes all of it (the **base** of the stack; the unit/integration `virtualenv` pin is stacked in #141):

1. **mypy — 7 errors in 4 files.** Targeted `# type: ignore[...]` on Airflow symbols the stubs don't expose (`AirflowException` re-export, `airflow.utils.context.Context`, subclassing `DecoratedOperator`, untyped `TriggerEvent`).
2. **cncf-kubernetes compat (version-robust).** `PodOperatorHookProtocol` was **removed** from newer providers, breaking `from airflow.providers.cncf.kubernetes.utils.pod_manager import PodOperatorHookProtocol` (test collection failed: `ImportError`). The two properties annotated with it already `return RayHook(...)`, so they're now annotated `-> RayHook` and the provider import is dropped — works on **both old and new** provider versions, no version-specific ignore.
3. **markdown-link-check** — the apache-airflow Slack invite returns HTTP 403 to bots; added to `mlc-config.json` `ignorePatterns`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
