### PR TITLE
Deprecate the astro-provider-ray project

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,17 @@
 CHANGELOG
 =========
 
+0.4.0 (2026-07-01)
+------------------
+
+**Deprecations**
+
+* Deprecate the ``astro-provider-ray`` project. The provider is no longer actively maintained by
+  Astronomer: development has been paused and we are not accepting new contributions, bug fixes or
+  releases. The project is marked inactive (``Development Status :: 7 - Inactive``) and now emits a
+  ``DeprecationWarning`` on import. Google Cloud users can use the Ray operators available in the
+  official Apache Airflow Google provider (``apache-airflow-providers-google``). by @pankajkoti.
+
 0.3.1 (2025-03-25)
 ------------------
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,25 @@
+## ⚠️ Discontinuation of project
+
+> This project is no longer actively maintained by Astronomer. Development has been paused and we are
+> not accepting new contributions, bug fixes or releases. The code is still here for you to explore,
+> fork and adapt under the terms of its license. Please note that it may not work with the latest
+> dependencies or platforms, and it could contain security vulnerabilities. Astronomer can't offer
+> guarantees or warranties for its use.
+>
+> **Google Cloud alternative (partial):** If you run Ray on Google Cloud, the official Apache Airflow
+> [Google provider](https://airflow.apache.org/docs/apache-airflow-providers-google/stable/index.html)
+> (`apache-airflow-providers-google`) ships Ray operators that cover a subset of what this provider does:
+> - Ray cluster lifecycle on Vertex AI — [`CreateRayClusterOperator`, `ListRayClustersOperator`, `GetRayClusterOperator`, `UpdateRayClusterOperator`, `DeleteRayClusterOperator`](https://github.com/apache/airflow/blob/main/providers/google/src/airflow/providers/google/cloud/operators/vertex_ai/ray.py)
+> - Ray job management — [`RaySubmitJobOperator`, `RayStopJobOperator`, `RayDeleteJobOperator`, `RayGetJobInfoOperator`, `RayListJobsOperator`](https://github.com/apache/airflow/blob/main/providers/google/src/airflow/providers/google/cloud/operators/ray.py)
+>
+> This provider is Kubernetes-generic, so the Google operators are a Google Cloud-specific alternative,
+> not a drop-in replacement.
+>
+> If you're interested in adopting or stewarding this project, we'd be happy to chat — reach us at
+> oss@astronomer.io. Thanks for being part of the open-source journey and helping keep great ideas alive!
+
+---
+
 <h1 align="center">
   Ray provider
 </h1>

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,6 +1,24 @@
 Welcome to the Ray provider documentation!
 ======================================
 
+.. warning::
+    **Discontinuation of project.** This project is no longer actively maintained by Astronomer.
+    Development has been paused and we are not accepting new contributions, bug fixes or releases.
+    The code is kept here for historical purposes; it may not work with the latest dependencies or
+    platforms and could contain security vulnerabilities, so Astronomer can't offer guarantees or
+    warranties for its use.
+
+    If you run Ray on Google Cloud, the official Apache Airflow Google provider
+    (``apache-airflow-providers-google``) ships Ray operators that cover a subset of this provider:
+    cluster lifecycle on Vertex AI (``CreateRayClusterOperator``, ``ListRayClustersOperator``,
+    ``GetRayClusterOperator``, ``UpdateRayClusterOperator``, ``DeleteRayClusterOperator``) and Ray job
+    management (``RaySubmitJobOperator``, ``RayStopJobOperator``, ``RayDeleteJobOperator``,
+    ``RayGetJobInfoOperator``, ``RayListJobsOperator``). This provider is Kubernetes-generic, so the
+    Google operators are a Google Cloud-specific alternative, not a drop-in replacement.
+
+    If you're interested in adopting or stewarding this project, reach us at oss@astronomer.io.
+    Thanks for being part of the open-source journey and helping keep great ideas alive!
+
 .. toctree::
    :hidden:
    :maxdepth: 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,8 +6,9 @@ build-backend = "hatchling.build"
 name = "astro-provider-ray"
 authors = [{ name = "Astronomer", email = "humans@astronomer.io" }]
 license = { text = "Apache License 2.0" }
-description = "An Apache Airflow provider package built by Astronomer to integrate with Ray."
+description = "[DEPRECATED - no longer maintained] An Apache Airflow provider package built by Astronomer to integrate with Ray."
 classifiers = [
+    "Development Status :: 7 - Inactive",
     "Framework :: Apache Airflow",
     "Framework :: Apache Airflow :: Provider",
     "Intended Audience :: Developers",

--- a/ray_provider/__init__.py
+++ b/ray_provider/__init__.py
@@ -1,8 +1,20 @@
 from __future__ import annotations
 
-__version__ = "0.3.1"
+import warnings
+
+__version__ = "0.4.0"
 
 from typing import Any
+
+warnings.warn(
+    "astro-provider-ray is no longer actively maintained by Astronomer. Development has been "
+    "paused and we are not accepting new contributions, bug fixes or releases. Google Cloud users "
+    "can use the Ray operators available in the official Apache Airflow Google provider "
+    "(apache-airflow-providers-google). If you're interested in adopting or taking over this "
+    "project, reach us at oss@astronomer.io.",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 
 # This is needed to allow Airflow to pick up specific metadata fields it needs for certain features.


### PR DESCRIPTION
## Summary

Deprecate the Astronomer-maintained Ray provider as part of the project to sunset/archive Astronomer-maintained providers. The provider is no longer actively maintained — development is paused and we are not accepting new contributions, bug fixes or releases.

Unlike the Databricks/Weaviate/Kafka archivals, there is **no Astronomer-donated upstream equivalent** — this provider's functionality is not being migrated into Apache Airflow. So this follows the lighter "⚠️ Discontinuation of project" template (cf. [airflow-ai-sdk#82](https://github.com/astronomer/airflow-ai-sdk/pull/82), [airflow-provider-weaviate#68](https://github.com/astronomer/airflow-provider-weaviate/pull/68), [astro-provider-snowflake#21](https://github.com/astronomer/astro-provider-snowflake/pull/21)).

For **Google Cloud users only**, a partial alternative exists in the official Apache Airflow Google provider (`apache-airflow-providers-google`):
- Ray cluster lifecycle on Vertex AI — `CreateRayClusterOperator`, `ListRayClustersOperator`, `GetRayClusterOperator`, `UpdateRayClusterOperator`, `DeleteRayClusterOperator` (analogous to `SetupRayCluster` / `DeleteRayCluster`).
- Ray job management — `RaySubmitJobOperator`, `RayStopJobOperator`, `RayDeleteJobOperator`, `RayGetJobInfoOperator`, `RayListJobsOperator` (analogous to `SubmitRayJob`).

This provider is Kubernetes-generic, so the Google operators are a GCP-specific alternative, **not a drop-in replacement** — the notices say so explicitly and invite anyone interested in adopting/stewarding the project to contact `oss@astronomer.io`.

## Changes

- **`ray_provider/__init__.py`**: bump `__version__` to `0.4.0`; emit a `DeprecationWarning` on import.
- **`pyproject.toml`**: add `Development Status :: 7 - Inactive` classifier; prefix the description with `[DEPRECATED - no longer maintained]` (surfaces on PyPI).
- **`README.md`** / **`docs/index.rst`**: add a `⚠️ Discontinuation of project` banner with the Google Cloud alternative.
- **`CHANGELOG.rst`**: add the `0.4.0 (2026-07-01)` entry.

## Follow-ups (outside this PR)

- Cut the `0.4.0` GitHub Release (planned **2026-07-01**) so the PyPI page reflects the deprecated/inactive metadata.
- Archive the GitHub repository.
- Update the tracking issue ([oss-integrations-private#410](https://github.com/astronomer/oss-integrations-private/issues/410)) and close the Linear ticket.

Ref: BOSS-374

🤖 Generated with [Claude Code](https://claude.com/claude-code)
