### PR TITLE
Release 0.4.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,13 @@ CHANGELOG
   ``DeprecationWarning`` on import. Google Cloud users can use the Ray operators available in the
   official Apache Airflow Google provider (``apache-airflow-providers-google``). by @pankajkoti.
 
+**Others**
+
+* Fix CI: resolve static check, unit and integration test failures on ``main`` by @tatiana in `#141 <https://github.com/astronomer/astro-provider-ray/pull/141>`_.
+* Add a 7-day Dependabot cooldown by @tatiana in `#140 <https://github.com/astronomer/astro-provider-ray/pull/140>`_.
+* Simplify CI authorization: add and later remove the Authorize job across the CI, docs and release workflows, and switch tests to the ``pull_request`` event by @pankajastro and @pankajkoti in #128, #129, #130, #131.
+* Bump GitHub Actions by @dependabot in #134, #135, #136, #137, #138, #144, #146, #148.
+
 0.3.1 (2025-03-25)
 ------------------
 


### PR DESCRIPTION
## CHANGELOG entry

0.4.0 (2026-07-01)

**Deprecations**

* Deprecate the ``astro-provider-ray`` project. The provider is no longer actively maintained by Astronomer: development has been paused and we are not accepting new contributions, bug fixes or releases. The project is marked inactive (``Development Status :: 7 - Inactive``) and now emits a ``DeprecationWarning`` on import. Google Cloud users can use the Ray operators available in the official Apache Airflow Google provider (``apache-airflow-providers-google``). by @pankajkoti.

**Others**

* Fix CI: resolve static check, unit and integration test failures on ``main`` by @tatiana in #141
* Add a 7-day Dependabot cooldown by @tatiana in #140
* Simplify CI authorization: add and later remove the Authorize job across the CI, docs and release workflows, and switch tests to the ``pull_request`` event by @pankajastro and @pankajkoti in #128, #129, #130, #131
* Bump GitHub Actions by @dependabot in #134, #135, #136, #137, #138, #144, #146, #148

## Summary

`0.4.0` is the **project-deprecation release** for `astro-provider-ray` (BOSS-374). The deprecation itself — the CHANGELOG `**Deprecations**` entry, the `__version__` bump to `0.4.0`, the `DeprecationWarning` on import, and the PyPI `Development Status :: 7 - Inactive` metadata — already landed on `main` via #154.

This PR **only backfills the `**Others**` section** of the `0.4.0` entry, documenting the CI / dependabot chores merged since `0.3.1`. Per the repo's own convention (see the `0.3.1` entry), those belong in the CHANGELOG; they were omitted when #154 added the deprecation entry. No code and no version change here — this is a CHANGELOG-only doc addition, and it's the branch the `v0.4.0` GitHub Release is cut from.

## Inclusion provenance

No milestone exists for this release. The `**Others**` entries were sourced from an undocumented-`main` sweep (PRs merged since the `0.3.1` cut vs. CHANGELOG references). No product / feature / bug-fix PRs were found undocumented — every gap since `0.3.1` is CI/infra:

| PRs | Notes |
|---|---|
| #128, #129, #130, #131 | CI authorization cleanup + switch tests to `pull_request` event (@pankajastro, @pankajkoti) |
| #141 | CI fix — static / unit / integration tests on `main` (@tatiana) |
| #140 | Dependabot 7-day cooldown config (@tatiana) |
| #134, #135, #136, #137, #138, #144, #146, #148 | Dependabot GitHub-action bumps |

## Test plan

Deprecation release — no functional DAGs to validate. Checklist:

- [ ] `python -c "import ray_provider"` emits the `DeprecationWarning` (already on `main` via #154).
- [ ] `ray_provider.__version__ == "0.4.0"`.
- [ ] After the `v0.4.0` GitHub Release is published, the [PyPI page](https://pypi.org/project/astro-provider-ray/) shows the `[DEPRECATED - no longer maintained]` description and the `Development Status :: 7 - Inactive` classifier.

## Reviewer checklist

- [ ] `**Others**` section wording / PR grouping reviewed
- [ ] Confirms no version-file change is intended (already `0.4.0` on `main`)
- [ ] Ready to mark non-draft + cut the `v0.4.0` GitHub Release
